### PR TITLE
Fix for next.js 12

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const { join, relative } = require('path')
 const generateName = require('css-class-generator')
 
-const CSS_LOADER_MATCH = join('compiled', 'css-loader', 'cjs.js')
+const CSS_LOADER_MATCH = join('loaders', 'css-loader', 'src', 'index.js')
 
 const names = {}
 let index = 0


### PR DESCRIPTION
It seems that "css-loader" paths have changed in next.js 12.
This change is not compatible with earlier versions of next.js.